### PR TITLE
Add a docker container definition to the item-scoring-service WAR.

### DIFF
--- a/equation-scoring-image/pom.xml
+++ b/equation-scoring-image/pom.xml
@@ -11,10 +11,6 @@
         <version>3.0.1-SNAPSHOT</version>
     </parent>
 
-    <properties>
-        <docker.image.prefix>fwsbac</docker.image.prefix>
-    </properties>
-
     <build>
         <plugins>
             <plugin>

--- a/item-scoring-service/pom.xml
+++ b/item-scoring-service/pom.xml
@@ -98,8 +98,7 @@
 			<artifactId>jcl-over-slf4j</artifactId>
 		</dependency>
 	</dependencies>
-	<build>
-	</build>
+
 	<reporting>
 		<plugins>
 			<!-- jxr creates cross a reference of the projects source, required by 
@@ -122,6 +121,31 @@
 			</plugin>
 		</plugins>
 	</reporting>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>0.4.10</version>
+				<configuration>
+					<imageName>${docker.image.prefix}/${project.artifactId}</imageName>
+					<imageTags>
+						<imageTag>${project.version}</imageTag>
+						<imageTag>latest</imageTag>
+					</imageTags>
+					<dockerDirectory>${project.basedir}/src/main/docker</dockerDirectory>
+					<resources>
+						<resource>
+							<targetPath>/</targetPath>
+							<directory>${project.build.directory}</directory>
+							<include>${project.build.finalName}.war</include>
+						</resource>
+					</resources>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<profiles>
 		<profile>

--- a/item-scoring-service/src/main/docker/Dockerfile
+++ b/item-scoring-service/src/main/docker/Dockerfile
@@ -1,0 +1,12 @@
+################
+# Docker file to build a docker servlet container hosting the Item Scoring Service WAR.
+################
+
+#Based off of the shared secure tomcat 7 image from SS_SharedMultiJar
+FROM fwsbac/secure-tomcat-image:3.0.1
+
+#Add the WAR file
+ADD item-scoring-service-*.war $CATALINA_HOME/webapps/itemscoring.war
+
+EXPOSE 8080
+CMD ["catalina.sh", "run"]

--- a/item-scoring-service/src/main/docker/docker-run.sample
+++ b/item-scoring-service/src/main/docker/docker-run.sample
@@ -1,0 +1,7 @@
+# Sample docker run command (replace values with your environment values)
+
+docker run -e "ITEMSCORING_QTI_SYMPYSERVICEURL=<equation-scoring-service-url>" \
+-e "ITEMSCORING_QTI_SYMPYMAXTRIES=3" \
+-e "ITEMSCORING_QTI_SYMPYTIMEOUTMILLIS=10000" \
+-e "QTHREADCOUNT=5" \
+-P <DOCKER_IMAGE_ID>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,10 @@
 		<module>qtiscoringengineTesterEQ</module>
 	</modules>
 
+	<properties>
+		<docker.image.prefix>fwsbac</docker.image.prefix>
+	</properties>
+
 	<licenses>
 		<license>
 			<name>AIR-License-1.0</name>


### PR DESCRIPTION
Wrap the item-scoring-service war in a Docker container.

NOTE: This service doesn't connect to ProgMan, so we'll need to use Environment Variables to externally define the URL for they python scoring service.